### PR TITLE
Add fields to new contact

### DIFF
--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -16,7 +16,10 @@ class SlackNotifier
       Email: #{contact.email}
       How they found us: #{contact.found_us}
       Request Type: #{contact.request_type&.titleize}\n
+      In House Developers: #{contact&.in_house_developers}\n
+      They plan to start at: #{contact&.starting_at}\n
       Cheers,\nYour OmbuLabs Robot!
+
     TEXT
   end
 end


### PR DESCRIPTION
We're adding two more fields to the form that will need to be sent to Slack.
This was already tested before when the service was a part of the original project.