### PR TITLE
Relax the rails version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ombu_labs-notifications (0.1.0)
-      rails (~> 6.0.0)
+      rails (>= 6.0)
       sidekiq (>= 5.0)
       slack-notifier (>= 2.4.0)
 
@@ -85,6 +85,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.1)
     minitest (5.16.3)
     net-imap (0.3.3)
       date
@@ -96,7 +97,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.13.10-arm64-darwin)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.1)
     rack (2.2.4)
@@ -144,6 +146,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.5.4)
+      mini_portile2 (~> 2.8.0)
     sqlite3 (1.5.4-arm64-darwin)
     thor (1.2.1)
     thread_safe (0.3.6)
@@ -157,6 +161,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  ruby
 
 DEPENDENCIES
   ombu_labs-notifications!

--- a/ombu_labs-notifications.gemspec
+++ b/ombu_labs-notifications.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 6.0"
+  spec.add_dependency "rails", ">= 6.0"
   spec.add_dependency "slack-notifier", ">= 2.4.0"
   spec.add_dependency "sidekiq", ">= 5.0"
 end


### PR DESCRIPTION
Hey @rishijain 

I needed to relax the Rails version on these gems now that the marketing team updated the Rails version in Fastruby.io, and they will soon in OmbuLabs.