### PR TITLE
FR-306, FR-307: Update the contact to have attributes that are optional

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ombu_labs-notifications (0.1.1)
+    ombu_labs-notifications (0.1.2)
       rails (>= 6.0)
       sidekiq (>= 5.0)
       slack-notifier (>= 2.4.0)

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -15,9 +15,9 @@ class SlackNotifier
       ```
       Email: #{contact.email}
       How they found us: #{contact.found_us}
-      Request Type: #{contact.request_type&.titleize}\n
-      In House Developers: #{contact&.in_house_developers}\n
-      They plan to start at: #{contact&.starting_at}\n
+      Request Type: #{contact["request_type"]&.titleize}\n
+      In House Developers: #{contact["in_house_developers"]}\n
+      They plan to start at: #{contact["starting_at"]}\n
       Cheers,\nYour OmbuLabs Robot!
 
     TEXT

--- a/lib/ombu_labs/notifications/version.rb
+++ b/lib/ombu_labs/notifications/version.rb
@@ -1,5 +1,5 @@
 module OmbuLabs
   module Notifications
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
This PR is helping with FastRuby.io, we are sending an email with information about the contact, but the request_type is no longer included and was therefor breaking the email send. This PR makes some of the contact attributes optional. This PR will fix the issue happening for:
https://github.com/ombulabs/fastruby.io/pull/531

@arielj  helped me to debug this issue