### PR TITLE
Used product along with request_type

### DIFF
--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -15,7 +15,7 @@ class SlackNotifier
       ```
       Email: #{contact.email}
       How they found us: #{contact.found_us}
-      Request Type: #{contact["request_type"]&.titleize}\n
+      Request Type: #{contact["request_type"]&.titleize || contact["product"]&.titleize}\n
       In House Developers: #{contact["in_house_developers"]}\n
       They plan to start at: #{contact["starting_at"]}\n
       Cheers,\nYour OmbuLabs Robot!


### PR DESCRIPTION
Here in the slack notifier class https://github.com/fastruby/ombu_labs-notifications/blob/main/app/services/slack_notifier.rb#L18, `request_type` has been used but the contact model in fastruby does not have any field called request_type. It has a field called product which is capturing the information that we need.

But OmbuLabs Contact model has a field called request_type. Since we are using the same gem for slack notifications in both the projects, we need to accommodate the use of both the field product and request_type.